### PR TITLE
Fix baseUrl customization from top derivation

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,15 +1,14 @@
 { pkgs ? import <nixpkgs> {}
-, name ? "personal-homepage"
 , baseUrl ? "https://frederic.menou.me"
 }:
 
 let
-  website   = pkgs.callPackage ./website   {};
+  website   = pkgs.callPackage ./website/package.nix { inherit baseUrl; };
   scripting = pkgs.callPackage ./scripting {};
 
 in
   pkgs.symlinkJoin {
-    inherit name;
+    name = "personal-homepage";
 
     paths = [
       # The order matters as they are potentially overriding files, so watch out!

--- a/scripting/default.nix
+++ b/scripting/default.nix
@@ -1,5 +1,4 @@
 { pkgs ? import <nixpkgs> {}
-, name ? "frontend"
 }:
 
 let
@@ -11,7 +10,7 @@ let
 
 in
   pkgs.stdenv.mkDerivation {
-    inherit name;
+    name = "personal-homepage-scripting";
 
     buildInputs = [
       spagoPkgs.installSpagoStyle

--- a/website/default.nix
+++ b/website/default.nix
@@ -1,27 +1,5 @@
 { pkgs ? import <nixpkgs> {}
-, name ? "homepage-statically-generated"
 , baseUrl ? "https://frederic.menou.me"
 }:
 
-let
-  gitignoreSource = pkgs.callPackage ../gitignore.nix { };
-
-in
-  pkgs.stdenv.mkDerivation {
-    inherit name;
-
-    nativeBuildInputs = with pkgs; [
-      zola
-    ];
-
-    src = gitignoreSource ./.;
-
-    buildPhase = ''
-      zola build -u ${baseUrl}
-    '';
-
-    installPhase = ''
-      mkdir $out
-      cp -r public/. $out/
-    '';
-  }
+pkgs.callPackage ./package.nix { inherit baseUrl; }

--- a/website/package.nix
+++ b/website/package.nix
@@ -1,0 +1,28 @@
+{ stdenv
+, callPackage
+, zola
+, baseUrl
+}:
+
+let
+  gitignoreSource = callPackage ../gitignore.nix { };
+
+in
+  stdenv.mkDerivation {
+    name = "personal-homepage-website";
+
+    nativeBuildInputs = [
+      zola
+    ];
+
+    src = gitignoreSource ./.;
+
+    buildPhase = ''
+      zola build -u ${baseUrl}
+    '';
+
+    installPhase = ''
+      mkdir $out
+      cp -r public/. $out/
+    '';
+  }


### PR DESCRIPTION
It appears setting the `baseUrl` argument when calling the root derivation wasn't properly passed to the `website/default.nix` derivation, no thanks to default argument values and callPackage not working together as I expected.

This fixes it.

I also dropped the `name` argument as it made not much sense and instead hardcode sensible names for each derivations now that the general layout of this project is good and stable enough.