### PR TITLE
Nginx support

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -1,0 +1,14 @@
+name: "Integration test"
+on:
+  pull_request:
+  push:
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2.4.0
+    - uses: cachix/install-nix-action@v16
+      with:
+        nix_path: nixpkgs=channel:nixos-22.05
+        extra_nix_config: "system-features = nixos-test benchmark big-parallel kvm"
+    - run: nix-build tests.nix

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,9 @@
+rewrite ^/about.html$     /about/                       last;
+rewrite ^/resume.html$    /resume/                      last;
+
+rewrite ^/blog$           /writings/                    last;
+rewrite ^/blog/(.*)$      /writings/$1                  last;
+rewrite ^/tutorials$      /tutorials-and-conferences/   last;
+rewrite ^/tutorials/(.*)$ /tutorials-and-conferences/$1 last;
+
+error_page 404 /404.html;

--- a/nginx.nix
+++ b/nginx.nix
@@ -1,0 +1,11 @@
+{ pkgs
+, baseUrl
+}:
+
+let
+  root = pkgs.callPackage ./website/package.nix { inherit baseUrl; };
+
+  extraConfig = builtins.readFile ./nginx.conf;
+
+in
+  { inherit root extraConfig; }

--- a/tests.nix
+++ b/tests.nix
@@ -1,0 +1,31 @@
+{ system ? builtins.currentSystem
+, pkgs ? import <nixpkgs> { inherit system; }
+}:
+
+with import <nixpkgs/nixos/lib/testing-python.nix> { inherit system pkgs; };
+
+let website = pkgs.callPackage ./nginx.nix { baseUrl = "http://localhost"; };
+in
+{
+  nginx = makeTest {
+    nodes.machine = { ... }: {
+      virtualisation.cores = 1;
+      virtualisation.memorySize = 256;
+
+      services.nginx.enable = true;
+      services.nginx.virtualHosts.local = {
+        locations."/" = {
+          inherit (website) root extraConfig;
+        };
+      };
+
+      environment.systemPackages = with pkgs; [ httpie ];
+    };
+
+    testScript = ''
+      machine.start();
+      machine.wait_for_unit("nginx.service");
+      machine.succeed("http http://localhost/sitemap.xml");
+    '';
+  };
+}


### PR DESCRIPTION
Add a dedicated derivation providing the nginx configuration, in the same spirit of Apache's httpd reading a `.htaccess`. It's up to the callee to actually use the configuration file, nothing magic happen.

A more extensive option could be to provide a NixOS module serving the website to make it a bit more consistent but that's quite some work. For now I'll stick to it being specified and maintained in [ptitfred/personal-infrastructure](https://github.com/ptitfred/personal-infrastructure).

It includes an [end-to-end test](https://github.com/ptitfred/personal-homepage/actions/runs/3235585668/jobs/5300220579#step:4:2363) of a VM with nginx using the extra configuration to make sure it's usable.

At some point some specific tests could be written, notably to ensure redirections for old URLs are working and not lost along the way.