### PR TITLE
Nginx support

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -1,9 +1,9 @@
-rewrite ^/about.html$     /about/                       last;
-rewrite ^/resume.html$    /resume/                      last;
+rewrite ^/about.html$     /about/                       permanent;
+rewrite ^/resume.html$    /resume/                      permanent;
 
-rewrite ^/blog$           /writings/                    last;
-rewrite ^/blog/(.*)$      /writings/$1                  last;
-rewrite ^/tutorials$      /tutorials-and-conferences/   last;
-rewrite ^/tutorials/(.*)$ /tutorials-and-conferences/$1 last;
+rewrite ^/blog$           /writings/                    permanent;
+rewrite ^/blog/(.*)$      /writings/$1                  permanent;
+rewrite ^/tutorials$      /tutorials-and-conferences/   permanent;
+rewrite ^/tutorials/(.*)$ /tutorials-and-conferences/$1 permanent;
 
 error_page 404 /404.html;

--- a/nginx.nix
+++ b/nginx.nix
@@ -3,7 +3,13 @@
 }:
 
 let
-  root = pkgs.callPackage ./website/package.nix { inherit baseUrl; };
+  website   = pkgs.callPackage ./website/package.nix { inherit baseUrl; };
+  scripting = pkgs.callPackage ./scripting {};
+
+  root = pkgs.symlinkJoin {
+    name = "personal-homepage";
+    paths = [ scripting website ];
+  };
 
   extraConfig = builtins.readFile ./nginx.conf;
 


### PR DESCRIPTION
- Old URLs should be 301s and not 200s
- Include scripting to nginx (not critical as the domain redirect is handled natively by nginx, but that would be a shame to forget it and later debug for hours why the patched javascript wasn't used 😬)