### PR TITLE
Deployable tool to take screenshots

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,8 +20,9 @@ jobs:
     - uses: actions/checkout@v3
     - uses: cachix/install-nix-action@v18
       with:
-        nix_path: nixpkgs=channel:nixos-22.05
+        nix_path: nixpkgs=channel:nixos-22.05:nixpkgs-overlays=./overlays
     - run: nix-build scripting
+    - run: nix-build scripts
     - run: nix-build --argstr baseUrl http://localhost:8000 website
     - run: nix-build --argstr baseUrl http://localhost:8000
     - run: ./take-screenshots.sh

--- a/overlays/posix-toolbox.nix
+++ b/overlays/posix-toolbox.nix
@@ -1,0 +1,7 @@
+let fetchPackage = self: definition: path:
+      self.callPackage (self.fetchFromGitHub (builtins.fromJSON (builtins.readFile definition)) + path) {};
+in
+  self: { ... }:
+    {
+      posix-toolbox = fetchPackage self ./ptitfred-posix-toolbox.json "/nix/default.nix";
+    }

--- a/overlays/ptitfred-posix-toolbox.json
+++ b/overlays/ptitfred-posix-toolbox.json
@@ -1,0 +1,7 @@
+{
+    "owner": "ptitfred",
+    "repo": "posix-toolbox",
+    "rev": "d31128c1c8bbf7907534377633a43477c2e8d521",
+    "sha256": "lhkGUYuMvIsBJfHJEeitiH58Yh29h7ePgracCevtHHc=",
+    "fetchSubmodules": false
+}

--- a/package.nix
+++ b/package.nix
@@ -21,4 +21,5 @@ in
     nginx = pkgs.callPackage webservers/nginx/package.nix {
       root = content;
     };
+    tools = pkgs.callPackage scripting/package.nix {};
   }

--- a/scripts/default.nix
+++ b/scripts/default.nix
@@ -1,0 +1,4 @@
+{ pkgs ? import <nixpkgs> {}
+}:
+
+pkgs.callPackage ./package.nix {}

--- a/scripts/package.nix
+++ b/scripts/package.nix
@@ -1,0 +1,11 @@
+{ pkgs
+, htmlq
+, imagemagick
+, lib
+, makeWrapper
+, puppeteer-cli
+, stdenv
+}:
+
+let wrapper = pkgs.callPackage ./wrapper.nix {};
+ in wrapper "take-screenshots.sh" [ imagemagick puppeteer-cli htmlq ]

--- a/scripts/take-screenshots.sh
+++ b/scripts/take-screenshots.sh
@@ -1,0 +1,42 @@
+set -e
+
+baseUrl="$1"
+output="$2"
+
+function listPages {
+  curl -s "$baseUrl/sitemap.xml" | htmlq -t urlset url loc
+}
+
+function readContentHash {
+  local url="$1"
+  curl -s "$url" | htmlq "meta[property=source_hash]" --attribute content
+}
+
+function takeScreenshot {
+  local url="$1"
+
+  hash=$(readContentHash "$url")
+  if [ -n "$hash" ]
+  then
+    puppeteer screenshot --viewport 1200x630 "$url" "$output/$hash-uncropped.png"
+    echo "Cropping to $output/$hash.png"
+    convert "$output/$hash-uncropped.png" -crop 1200x630+0+0 "$output/$hash.png"
+    rm "$output/$hash-uncropped.png"
+  fi
+}
+
+function takeScreenshots {
+  while read -r url ; do takeScreenshot "$url" ; done
+}
+
+function proceed {
+  listPages | takeScreenshots
+}
+
+function sumUp {
+  echo "--"
+  echo "$(find $output -name '*.png' | wc -l) screenshots taken, good bye."
+}
+
+proceed
+sumUp

--- a/scripts/wrapper.nix
+++ b/scripts/wrapper.nix
@@ -1,0 +1,18 @@
+{ stdenv, lib, makeWrapper }:
+
+script: inputs:
+  stdenv.mkDerivation rec {
+    name = "personal-homepage-scripts-" + script;
+
+    src = ./.;
+
+    buildInputs = inputs ++ [ makeWrapper ] ;
+
+    installPhase =
+      let runtimePath = lib.makeBinPath inputs;
+       in ''
+            mkdir -p $out/bin
+            cp $src/${script} $out/bin/${script}
+            wrapProgram $out/bin/${script} --prefix PATH : "${runtimePath}"
+          '';
+  }

--- a/take-screenshots.sh
+++ b/take-screenshots.sh
@@ -1,6 +1,6 @@
 #! /usr/bin/env nix-shell
 # shellcheck shell=bash
-#! nix-shell -i bash -p python38 imagemagick puppeteer-cli htmlq jq
+#! nix-shell -i bash -p python38 imagemagick puppeteer-cli htmlq jq posix-toolbox.wait-tcp
 
 set -e
 
@@ -21,49 +21,17 @@ function setup {
   trap 'kill $COPROC_PID' err exit
 }
 
-function listPages {
-  local path="$1"
-  htmlq -t urlset url loc < "${path}/sitemap.xml"
-}
-
-function readContentHash {
-  local url="$1"
-  curl -s "$url" | htmlq "meta[property=source_hash]" --attribute content
-}
-
-function takeScreenshot {
-  local url="$1"
-
-  hash=$(readContentHash "$url")
-  if [ -n "$hash" ]
-  then
-    puppeteer screenshot --viewport 1200x630 "$url" "screenshots/$hash-uncropped.png"
-    echo "Cropping to screenshots/$hash.png"
-    convert "screenshots/$hash-uncropped.png" -crop 1200x630+0+0 "screenshots/$hash.png"
-    rm "screenshots/$hash-uncropped.png"
-  fi
-}
-
-function takeScreenshots {
-  while read -r line ; do takeScreenshot "$line" ; done
-}
-
 function serveWebsite {
   local path="$1"
   coproc python3 -m http.server "$port" --directory "$path"
 }
 
-function proceed {
+function build {
   static=$(buildStatic | readStorePath)
   serveWebsite "$static"
-  listPages "$static" | takeScreenshots
-}
-
-function sumUp {
-  echo "--"
-  echo "$(find screenshots -name '*.png' | wc -l) screenshots taken, good bye."
 }
 
 setup
-proceed
-sumUp
+build
+wait-tcp $port
+scripts/take-screenshots.sh "$baseUrl" screenshots


### PR DESCRIPTION
In a perfect world I would take screenshots at build time and include them in the website before deployment. For now it doesn't work, mainly because of chromium not reacting well to nix sandboxing.

The only reasonable fallback I can see is to hook the screenshots script at deployment. It will probably be done via a one-shot systemd unit triggered by fresh deployment. It requires a bit more configuration to let the website know where to look assets from. A dedicated location in the virtualhost from a local directory could do the trick.