### PR TITLE
Tools: name scripts for outside usage

### DIFF
--- a/package.nix
+++ b/package.nix
@@ -21,5 +21,5 @@ in
     nginx = pkgs.callPackage webservers/nginx/package.nix {
       root = content;
     };
-    tools = pkgs.callPackage scripting/package.nix {};
+    tools = pkgs.callPackage scripts/package.nix {};
   }

--- a/scripts/package.nix
+++ b/scripts/package.nix
@@ -1,11 +1,10 @@
 { pkgs
+, curl
 , htmlq
 , imagemagick
-, lib
-, makeWrapper
 , puppeteer-cli
-, stdenv
 }:
 
 let wrapper = pkgs.callPackage ./wrapper.nix {};
- in wrapper "take-screenshots.sh" [ imagemagick puppeteer-cli htmlq ]
+    take-screenshots = wrapper "take-screenshots.sh" [ curl htmlq imagemagick puppeteer-cli ];
+in { inherit take-screenshots; }


### PR DESCRIPTION
Having the top derivation binding a single script to the "tools" attribute wasn't making sense. Also who knows how many scripts we might need later on?

Bonuses: fix a typo and a missing dependency.