### PR TITLE
Skip screenshot for a page when already there

### DIFF
--- a/scripts/take-screenshots.sh
+++ b/scripts/take-screenshots.sh
@@ -18,10 +18,15 @@ function takeScreenshot {
   hash=$(readContentHash "$url")
   if [ -n "$hash" ]
   then
-    puppeteer screenshot --viewport 1200x630 "$url" "$output/$hash-uncropped.png"
-    echo "Cropping to $output/$hash.png"
-    convert "$output/$hash-uncropped.png" -crop 1200x630+0+0 "$output/$hash.png"
-    rm "$output/$hash-uncropped.png"
+    if [ -r "$output/$hash.png" ]
+    then
+      echo "$output/$hash.png already present, skipping"
+    else
+      puppeteer screenshot --viewport 1200x630 "$url" "$output/$hash-uncropped.png"
+      echo "Cropping to $output/$hash.png"
+      convert "$output/$hash-uncropped.png" -crop 1200x630+0+0 "$output/$hash.png"
+      rm "$output/$hash-uncropped.png"
+    fi
   fi
 }
 


### PR DESCRIPTION
It's solely relying on the hash from the source, so it's not totally reliable (for instance if the CSS or assets change). A way to solve that would be to clear the directory before hand.