### PR TITLE
Zola: change syntax theme to match the design

### DIFF
--- a/website/config.toml
+++ b/website/config.toml
@@ -36,6 +36,7 @@ nix = "Nix"
 # Whether to do syntax highlighting
 # Theme can be customised by setting the `highlight_theme` variable to a theme supported by Zola
 highlight_code = true
+highlight_theme = "ayu-dark"
 extra_syntaxes_and_themes = ["syntaxes"]
 
 external_links_target_blank = true


### PR DESCRIPTION
It looks like this:

<img width=75% src=https://github.com/ptitfred/personal-homepage/assets/346377/e04bff09-ddc2-4b86-bed0-be9ff5036438/>
