### PR TITLE
Update posix-toolbox

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -134,11 +134,11 @@
         "trapd00r-ls-colors": "trapd00r-ls-colors"
       },
       "locked": {
-        "lastModified": 1729256231,
-        "narHash": "sha256-8yWAk8fBd5lkPK+fbAJK11DVi0RhR+klb+2PTixy1Sg=",
+        "lastModified": 1729257107,
+        "narHash": "sha256-dqA5jHajdi+rDnyoxnPKFczXWQEJdvYGEnozolYa4Tc=",
         "owner": "ptitfred",
         "repo": "posix-toolbox",
-        "rev": "e7fe51165fac57d159518344dc6904f644853cfd",
+        "rev": "fcf9e56d986a724b2fc7bfbc756f008019fec270",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -34,7 +34,7 @@
 
       overlays = [
         overlay
-        posix-toolbox.overlay
+        posix-toolbox.overlays.default
       ];
 
       tests =


### PR DESCRIPTION
The deprecated `overlay` output isn't available anymore.