### PR TITLE
Automated flake inputs updated

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -112,11 +112,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1729044727,
-        "narHash": "sha256-GKJjtPY+SXfLF/yTN7M2cAnQB6RERFKnQhD8UvPSf3M=",
+        "lastModified": 1729449015,
+        "narHash": "sha256-Gf04dXB0n4q0A9G5nTGH3zuMGr6jtJppqdeljxua1fo=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "dc2e0028d274394f73653c7c90cc63edbb696be1",
+        "rev": "89172919243df199fe237ba0f776c3e3e3d72367",
         "type": "github"
       },
       "original": {
@@ -134,11 +134,11 @@
         "trapd00r-ls-colors": "trapd00r-ls-colors"
       },
       "locked": {
-        "lastModified": 1729717544,
-        "narHash": "sha256-ifNn2ufQfBbJ8wm3oXjUY9yioUaSGR+Oe+K4xCqUP4w=",
+        "lastModified": 1729764507,
+        "narHash": "sha256-D9AI8eUTLXYxeuKi0Sr2Och4pA8QWpzPXASpDrfUfDg=",
         "owner": "ptitfred",
         "repo": "posix-toolbox",
-        "rev": "e3f3f73f008f242aefb3eb8924256914c2e8e532",
+        "rev": "74af6ccb56841b45df700d588ec48cdfd7baeede",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
• Updated input 'posix-toolbox':
    'github:ptitfred/posix-toolbox/e3f3f73f008f242aefb3eb8924256914c2e8e532' (2024-10-23)
  → 'github:ptitfred/posix-toolbox/74af6ccb56841b45df700d588ec48cdfd7baeede' (2024-10-24)
• Updated input 'posix-toolbox/nixpkgs':
    'github:nixos/nixpkgs/dc2e0028d274394f73653c7c90cc63edbb696be1' (2024-10-16)
  → 'github:nixos/nixpkgs/89172919243df199fe237ba0f776c3e3e3d72367' (2024-10-20)
```