### PR TITLE
Update & fix open-source section

### DIFF
--- a/website/content/open-source.md
+++ b/website/content/open-source.md
@@ -7,16 +7,16 @@ hide_toc = "true"
 hide_read_more = "true"
 +++
 
-## Tooling and recurring configuration
+## Tooling and configuration
 
-- [ptitfred/posix-toolbox](https://github.com/ptitfred/posix-toolbox): Set of tools for the shell that I use, mainly scripts. Some are very old (> 10 years) and I don't use all of them anymore.
-- [ptitfred/home-manager](https://github.com/ptitfred/home-manager): My main home-manager configuration files (previously named `nixos-configuration` ; now fixed to a proper name).
+- [ptitfred/posix-toolbox](https://github.com/ptitfred/posix-toolbox): Collection of tools I daily use, mainly bash scripts (sorry). Made with :heart: since 2007. I actively use it so don't hesitate to take a look at it!
+- [ptitfred/personal-infrastructure](https://github.com/ptitfred/personal-infrastructure): My declarative [Nix](https://nixos.org/) configurations of my laptop and servers. Uses [home-manager](https://nix-community.github.io/home-manager/) for user land and [colmena](https://colmena.cli.rs) for system configurations and deployment.
 
 ## Meetups, conferences and similar materials
 
 - [ptitfred/slides](https://github.com/ptitfred/slides): two HTML presentations from 2013
 - [ptitfred/slidecoding](https://github.com/ptitfred/slidecoding): an attempt at interactive slideshare with split screen slides and haskell REPL. It includes 1 presentation done at Devfest Nantes November 2016.
-- [Slides ScalaIO 2017](https://github.com/ptitfred/slides-scalaio-2017): an attempt at interactive slideshare with split screen slides and haskell REPL. It includes 1 presentation done at Devfest Nantes November 2016. Recording [available here](@/tutorials-and-conferences/2017-11-02_haskell-in-production-scalaio.md).
+- [Slides ScalaIO 2017](https://github.com/ptitfred/slides-scalaio-2017): an introduction to Haskell as a viable option in startup, co-hosted with [Clément Delafargue](https://blog.clement.delafargue.name/). Recording [available here](@/tutorials-and-conferences/2017-11-02_haskell-in-production-scalaio.md).
 
 ## This very website
 

--- a/website/content/tutorials-and-conferences/2017-11-02_haskell-in-production-scalaio.md
+++ b/website/content/tutorials-and-conferences/2017-11-02_haskell-in-production-scalaio.md
@@ -1,6 +1,6 @@
 +++
 title = "Haskell en production en 2017 dans une startup ? Yup."
-description = "Conference at ScalaIO '17 with [Clément Delafargue](https://twitter.com/clementd)."
+description = "Conference at ScalaIO '17 with [Clément Delafargue](https://blog.clement.delafargue.name/)."
 date = 2017-11-02
 [taxonomies]
 programming-languages = ["haskell"]
@@ -10,7 +10,7 @@ contexts = ["conference"]
 tags = ["conference", "french"]
 +++
 
-Conference at ScalaIO '17', in French, with [Clément Delafargue](https://twitter.com/clementd):
+Conference at ScalaIO '17', in French, with [Clément Delafargue](https://blog.clement.delafargue.name/):
 
 {{ youtube(id="yKA-hYZa2tQ", class="yt_embed") }}
 

--- a/website/content/writings/2024-01-29_bye-haskell-hello-rust/index.md
+++ b/website/content/writings/2024-01-29_bye-haskell-hello-rust/index.md
@@ -88,7 +88,7 @@ Around Christmas 2023, I was a bit bored and took some time to read [the Rust Pr
 I was aware of Rust since 2014 as [Tristram], a colleague of mine at [Capitaine Train], ~~used it for a routing engine~~ who was a strong advocate but had to use C++ at the time, and as [Clément], a as-of-then future colleague of mine, talked about it at ScalaIO 2015. And we had a optimization tool at [Fretlink] developed by [Axelle]. But I never did take the time to study it.
 
 [Tristram]: https://mamot.fr/@tristramg
-[Clément]: https://framapiaf.org/@clementd
+[Clément]: https://blog.clement.delafargue.name/
 [Axelle]: https://www.linkedin.com/in/axelle-piot-a987a0b8/
 
 **Edit**: _Tristram [notified me](https://mamot.fr/@tristramg/111838910731745483) he did not use Rust for the routing engine and had to suffer using C++, Rust not being mature enough at the time._


### PR DESCRIPTION
- `home-manager` has been merged into `personal-infrastructure`. The description has been updated accordingly.
- The description of `posix-toolbox` has been refreshed.
- The description of `Slides ScalaIO 2017` was wrong. Credits to @divarvel.