### PR TITLE
Automated flake inputs updated

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -112,11 +112,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1729691686,
-        "narHash": "sha256-BAuPWW+9fa1moZTU+jFh+1cUtmsuF8asgzFwejM4wac=",
+        "lastModified": 1730137625,
+        "narHash": "sha256-9z8oOgFZiaguj+bbi3k4QhAD6JabWrnv7fscC/mt0KE=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "32e940c7c420600ef0d1ef396dc63b04ee9cad37",
+        "rev": "64b80bfb316b57cdb8919a9110ef63393d74382a",
         "type": "github"
       },
       "original": {
@@ -134,11 +134,11 @@
         "trapd00r-ls-colors": "trapd00r-ls-colors"
       },
       "locked": {
-        "lastModified": 1729846061,
-        "narHash": "sha256-E9kD8L39xKMIKY1lhCGIwZ6SjQbKVfc+tn/Oh35tZGU=",
+        "lastModified": 1730219815,
+        "narHash": "sha256-QMSCDZ5TLFnSxd4ia1IymuaebNNAdU+besKfwZj59VQ=",
         "owner": "ptitfred",
         "repo": "posix-toolbox",
-        "rev": "c1765143f3d8df604d5c04fdef78f62e98d7fbec",
+        "rev": "658ff2ba30c4f760c2cb9d4e95c6e93e38c4ef56",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Changes:

```
• Updated input 'posix-toolbox':
    'github:ptitfred/posix-toolbox/c1765143f3d8df604d5c04fdef78f62e98d7fbec' (2024-10-25)
  → 'github:ptitfred/posix-toolbox/658ff2ba30c4f760c2cb9d4e95c6e93e38c4ef56' (2024-10-29)
• Updated input 'posix-toolbox/nixpkgs':
    'github:nixos/nixpkgs/32e940c7c420600ef0d1ef396dc63b04ee9cad37' (2024-10-23)
  → 'github:nixos/nixpkgs/64b80bfb316b57cdb8919a9110ef63393d74382a' (2024-10-28)
```
