### PR TITLE
Automated flake inputs updated

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -112,11 +112,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1730137625,
-        "narHash": "sha256-9z8oOgFZiaguj+bbi3k4QhAD6JabWrnv7fscC/mt0KE=",
+        "lastModified": 1730327045,
+        "narHash": "sha256-xKel5kd1AbExymxoIfQ7pgcX6hjw9jCgbiBjiUfSVJ8=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "64b80bfb316b57cdb8919a9110ef63393d74382a",
+        "rev": "080166c15633801df010977d9d7474b4a6c549d7",
         "type": "github"
       },
       "original": {
@@ -134,11 +134,11 @@
         "trapd00r-ls-colors": "trapd00r-ls-colors"
       },
       "locked": {
-        "lastModified": 1730219815,
-        "narHash": "sha256-QMSCDZ5TLFnSxd4ia1IymuaebNNAdU+besKfwZj59VQ=",
+        "lastModified": 1730714793,
+        "narHash": "sha256-7rbUcQDvY231LaM1zgp6ciCAdnn8TibfMh9f55MVARo=",
         "owner": "ptitfred",
         "repo": "posix-toolbox",
-        "rev": "658ff2ba30c4f760c2cb9d4e95c6e93e38c4ef56",
+        "rev": "a543d43898b6b6d69121630d96e0ad2df3853b86",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Changes:

```
• Updated input 'posix-toolbox':
    'github:ptitfred/posix-toolbox/658ff2ba30c4f760c2cb9d4e95c6e93e38c4ef56' (2024-10-29)
  → 'github:ptitfred/posix-toolbox/a543d43898b6b6d69121630d96e0ad2df3853b86' (2024-11-04)
• Updated input 'posix-toolbox/nixpkgs':
    'github:nixos/nixpkgs/64b80bfb316b57cdb8919a9110ef63393d74382a' (2024-10-28)
  → 'github:nixos/nixpkgs/080166c15633801df010977d9d7474b4a6c549d7' (2024-10-30)
```
