### PR TITLE
Automated flake inputs updated

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -112,11 +112,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1730741070,
-        "narHash": "sha256-edm8WG19kWozJ/GqyYx2VjW99EdhjKwbY3ZwdlPAAlo=",
+        "lastModified": 1731239293,
+        "narHash": "sha256-q2yjIWFFcTzp5REWQUOU9L6kHdCDmFDpqeix86SOvDc=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "d063c1dd113c91ab27959ba540c0d9753409edf3",
+        "rev": "9256f7c71a195ebe7a218043d9f93390d49e6884",
         "type": "github"
       },
       "original": {
@@ -134,11 +134,11 @@
         "trapd00r-ls-colors": "trapd00r-ls-colors"
       },
       "locked": {
-        "lastModified": 1730912555,
-        "narHash": "sha256-bdil2mbKDONFzq9MltLi/yh2JAY/MBKByLAmZz0wF5Y=",
+        "lastModified": 1731407174,
+        "narHash": "sha256-9K7WAsPJVZbCeJoJltnFA1Olxc+uuC9YJKQNSN0Rsw8=",
         "owner": "ptitfred",
         "repo": "posix-toolbox",
-        "rev": "9e55ac052a9c3758f53aa2c57019e8111349dcc0",
+        "rev": "d981feee1fdba91c93b524c230f5ceb4b3c3ac1b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Changes:

```
• Updated input 'posix-toolbox':
    'github:ptitfred/posix-toolbox/9e55ac052a9c3758f53aa2c57019e8111349dcc0' (2024-11-06)
  → 'github:ptitfred/posix-toolbox/d981feee1fdba91c93b524c230f5ceb4b3c3ac1b' (2024-11-12)
• Updated input 'posix-toolbox/nixpkgs':
    'github:nixos/nixpkgs/d063c1dd113c91ab27959ba540c0d9753409edf3' (2024-11-04)
  → 'github:nixos/nixpkgs/9256f7c71a195ebe7a218043d9f93390d49e6884' (2024-11-10)
```
