### PR TITLE
Release 24.11

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -64,16 +64,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1726989464,
-        "narHash": "sha256-Vl+WVTJwutXkimwGprnEtXc/s/s8sMuXzqXaspIGlwM=",
+        "lastModified": 1732466619,
+        "narHash": "sha256-T1e5oceypZu3Q8vzICjv1X/sGs9XfJRMW5OuXHgpB3c=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "2f23fa308a7c067e52dfcc30a0758f47043ec176",
+        "rev": "f3111f62a23451114433888902a55cf0692b408d",
         "type": "github"
       },
       "original": {
         "owner": "nix-community",
-        "ref": "release-24.05",
+        "ref": "release-24.11",
         "repo": "home-manager",
         "type": "github"
       }
@@ -96,32 +96,32 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1720535198,
-        "narHash": "sha256-zwVvxrdIzralnSbcpghA92tWu2DV2lwv89xZc8MTrbg=",
+        "lastModified": 1732981179,
+        "narHash": "sha256-F7thesZPvAMSwjRu0K8uFshTk3ZZSNAsXTIFvXBT+34=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "205fd4226592cc83fd4c0885a3e4c9c400efabb5",
+        "rev": "62c435d93bf046a5396f3016472e8f7c8e2aed65",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
-        "ref": "nixos-23.11",
+        "ref": "nixos-24.11",
         "repo": "nixpkgs",
         "type": "github"
       }
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1731797254,
-        "narHash": "sha256-df3dJApLPhd11AlueuoN0Q4fHo/hagP75LlM5K1sz9g=",
+        "lastModified": 1732981179,
+        "narHash": "sha256-F7thesZPvAMSwjRu0K8uFshTk3ZZSNAsXTIFvXBT+34=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "e8c38b73aeb218e27163376a2d617e61a2ad9b59",
+        "rev": "62c435d93bf046a5396f3016472e8f7c8e2aed65",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
-        "ref": "nixos-24.05",
+        "ref": "nixos-24.11",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -134,11 +134,11 @@
         "trapd00r-ls-colors": "trapd00r-ls-colors"
       },
       "locked": {
-        "lastModified": 1731925134,
-        "narHash": "sha256-spEUZexvrIWGydujwFJX4fLAt6csr1dUVpR0Kf8CeFg=",
+        "lastModified": 1733156007,
+        "narHash": "sha256-y/JmdoNmN42ybqHMbBzGtQXgbnv1gxV/F3HnClnz0Ys=",
         "owner": "ptitfred",
         "repo": "posix-toolbox",
-        "rev": "7f016c813e569effc75bd5537fde6bbd6c7cefa8",
+        "rev": "5b8e5187db506ee70a2120b15894a3f8d52233d8",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,7 @@
   description = "Personal homepage (frederic.menou.me)";
 
   inputs = {
-    nixpkgs.url = "github:nixos/nixpkgs/nixos-23.11";
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-24.11";
     gitignore.url = "github:hercules-ci/gitignore.nix";
     gitignore.inputs.nixpkgs.follows = "nixpkgs";
     posix-toolbox.url = "github:ptitfred/posix-toolbox";

--- a/garnix.yaml
+++ b/garnix.yaml
@@ -1,0 +1,11 @@
+builds:
+  # Currently the VM hangs at shutdown in Garnix
+  exclude:
+  - packages.*.integration-tests
+  include:
+  - '*.x86_64-linux.*'
+  - defaultPackage.x86_64-linux
+  - devShell.x86_64-linux
+  - homeConfigurations.*
+  - darwinConfigurations.*
+  - nixosConfigurations.*

--- a/tests/local.nix
+++ b/tests/local.nix
@@ -1,12 +1,12 @@
 { writeShellApplication
-, python38
+, python39
 , port
 , static
 }:
 
 writeShellApplication {
   name = "local";
-  runtimeInputs = [ python38 ];
+  runtimeInputs = [ python39 ];
   text = ''
     echo "Serving ${static}"
     python3 -m http.server ${port} --directory ${static}

--- a/tests/screenshots.nix
+++ b/tests/screenshots.nix
@@ -1,5 +1,5 @@
 { writeShellApplication
-, python38
+, python39
 , posix-toolbox
 , ptitfred
 , port
@@ -9,7 +9,7 @@
 
 writeShellApplication {
   name = "tests";
-  runtimeInputs = [ python38 posix-toolbox.wait-tcp ptitfred.take-screenshots ];
+  runtimeInputs = [ python39 posix-toolbox.wait-tcp ptitfred.take-screenshots ];
   text = ''
     set -e
 

--- a/website/config.toml
+++ b/website/config.toml
@@ -12,8 +12,8 @@ build_search_index = false
 
 minify_html = true
 
-generate_feed = true
-feed_filename = "rss.xml"
+generate_feeds = true
+feed_filenames = ["rss.xml"]
 
 taxonomies = [
   { name = "contexts" },


### PR DESCRIPTION
- python38 replaced by python39 as python3 implementation
- zola upgraded from 0.18.0 to 0.19.2

CI (Garnix): Temporarly exclude the integration tests as the VM hangs
out when shutting down. Maybe a 24.11 bug, maybe a Garnix bug. I'm too
old to investigate.