### PR TITLE
Automated flake inputs updated

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -64,11 +64,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1732466619,
-        "narHash": "sha256-T1e5oceypZu3Q8vzICjv1X/sGs9XfJRMW5OuXHgpB3c=",
+        "lastModified": 1733572789,
+        "narHash": "sha256-zjO6m5BqxXIyjrnUziAzk4+T4VleqjstNudSqWcpsHI=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "f3111f62a23451114433888902a55cf0692b408d",
+        "rev": "c7ffc9727d115e433fd884a62dc164b587ff651d",
         "type": "github"
       },
       "original": {
@@ -96,11 +96,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1733550349,
-        "narHash": "sha256-NcGumB4Lr6KSDq+nIqXtNA8QwAQKDSZT7N9OTGWbTrs=",
+        "lastModified": 1733808091,
+        "narHash": "sha256-KWwINTQelKOoQgrXftxoqxmKFZb9pLVfnRvK270nkVk=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "e2605d0744c2417b09f8bf850dfca42fcf537d34",
+        "rev": "a0f3e10d94359665dba45b71b4227b0aeb851f8e",
         "type": "github"
       },
       "original": {
@@ -112,11 +112,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1732981179,
-        "narHash": "sha256-F7thesZPvAMSwjRu0K8uFshTk3ZZSNAsXTIFvXBT+34=",
+        "lastModified": 1733550349,
+        "narHash": "sha256-NcGumB4Lr6KSDq+nIqXtNA8QwAQKDSZT7N9OTGWbTrs=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "62c435d93bf046a5396f3016472e8f7c8e2aed65",
+        "rev": "e2605d0744c2417b09f8bf850dfca42fcf537d34",
         "type": "github"
       },
       "original": {
@@ -134,11 +134,11 @@
         "trapd00r-ls-colors": "trapd00r-ls-colors"
       },
       "locked": {
-        "lastModified": 1733156007,
-        "narHash": "sha256-y/JmdoNmN42ybqHMbBzGtQXgbnv1gxV/F3HnClnz0Ys=",
+        "lastModified": 1733829714,
+        "narHash": "sha256-H1dXglbU7V3Ssg8C1MhVOonalNRJPHBQFjB61fFf+Wo=",
         "owner": "ptitfred",
         "repo": "posix-toolbox",
-        "rev": "5b8e5187db506ee70a2120b15894a3f8d52233d8",
+        "rev": "a9293f5737e6308bfcb13be81835f30ff59fd06b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Changes:

```
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/e2605d0744c2417b09f8bf850dfca42fcf537d34' (2024-12-07)
  → 'github:nixos/nixpkgs/a0f3e10d94359665dba45b71b4227b0aeb851f8e' (2024-12-10)
• Updated input 'posix-toolbox':
    'github:ptitfred/posix-toolbox/5b8e5187db506ee70a2120b15894a3f8d52233d8' (2024-12-02)
  → 'github:ptitfred/posix-toolbox/a9293f5737e6308bfcb13be81835f30ff59fd06b' (2024-12-10)
• Updated input 'posix-toolbox/home-manager':
    'github:nix-community/home-manager/f3111f62a23451114433888902a55cf0692b408d' (2024-11-24)
  → 'github:nix-community/home-manager/c7ffc9727d115e433fd884a62dc164b587ff651d' (2024-12-07)
• Updated input 'posix-toolbox/nixpkgs':
    'github:nixos/nixpkgs/62c435d93bf046a5396f3016472e8f7c8e2aed65' (2024-11-30)
  → 'github:nixos/nixpkgs/e2605d0744c2417b09f8bf850dfca42fcf537d34' (2024-12-07)
```
