### PR TITLE
Automated flake inputs updated

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -64,11 +64,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1733572789,
-        "narHash": "sha256-zjO6m5BqxXIyjrnUziAzk4+T4VleqjstNudSqWcpsHI=",
+        "lastModified": 1733951536,
+        "narHash": "sha256-Zb5ZCa7Xj+0gy5XVXINTSr71fCfAv+IKtmIXNrykT54=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "c7ffc9727d115e433fd884a62dc164b587ff651d",
+        "rev": "1318c3f3b068cdcea922fa7c1a0a1f0c96c22f5f",
         "type": "github"
       },
       "original": {
@@ -96,11 +96,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1733808091,
-        "narHash": "sha256-KWwINTQelKOoQgrXftxoqxmKFZb9pLVfnRvK270nkVk=",
+        "lastModified": 1734323986,
+        "narHash": "sha256-m/lh6hYMIWDYHCAsn81CDAiXoT3gmxXI9J987W5tZrE=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "a0f3e10d94359665dba45b71b4227b0aeb851f8e",
+        "rev": "394571358ce82dff7411395829aa6a3aad45b907",
         "type": "github"
       },
       "original": {
@@ -112,11 +112,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1733550349,
-        "narHash": "sha256-NcGumB4Lr6KSDq+nIqXtNA8QwAQKDSZT7N9OTGWbTrs=",
+        "lastModified": 1733808091,
+        "narHash": "sha256-KWwINTQelKOoQgrXftxoqxmKFZb9pLVfnRvK270nkVk=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "e2605d0744c2417b09f8bf850dfca42fcf537d34",
+        "rev": "a0f3e10d94359665dba45b71b4227b0aeb851f8e",
         "type": "github"
       },
       "original": {
@@ -134,11 +134,11 @@
         "trapd00r-ls-colors": "trapd00r-ls-colors"
       },
       "locked": {
-        "lastModified": 1733829714,
-        "narHash": "sha256-H1dXglbU7V3Ssg8C1MhVOonalNRJPHBQFjB61fFf+Wo=",
+        "lastModified": 1734023429,
+        "narHash": "sha256-Uzj0Rk65aiXRhyE+GTaoA0eU3oBGIUvg6MPsif1e3NQ=",
         "owner": "ptitfred",
         "repo": "posix-toolbox",
-        "rev": "a9293f5737e6308bfcb13be81835f30ff59fd06b",
+        "rev": "a36c60610fc68d905aa610546fba9a16db9e62f3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Changes:

```
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/a0f3e10d94359665dba45b71b4227b0aeb851f8e' (2024-12-10)
  → 'github:nixos/nixpkgs/394571358ce82dff7411395829aa6a3aad45b907' (2024-12-16)
• Updated input 'posix-toolbox':
    'github:ptitfred/posix-toolbox/a9293f5737e6308bfcb13be81835f30ff59fd06b' (2024-12-10)
  → 'github:ptitfred/posix-toolbox/a36c60610fc68d905aa610546fba9a16db9e62f3' (2024-12-12)
• Updated input 'posix-toolbox/home-manager':
    'github:nix-community/home-manager/c7ffc9727d115e433fd884a62dc164b587ff651d' (2024-12-07)
  → 'github:nix-community/home-manager/1318c3f3b068cdcea922fa7c1a0a1f0c96c22f5f' (2024-12-11)
• Updated input 'posix-toolbox/nixpkgs':
    'github:nixos/nixpkgs/e2605d0744c2417b09f8bf850dfca42fcf537d34' (2024-12-07)
  → 'github:nixos/nixpkgs/a0f3e10d94359665dba45b71b4227b0aeb851f8e' (2024-12-10)
```
