### PR TITLE
Backport the NixOS module from infrastructure

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -28,7 +28,9 @@
         easy-ps = easy-ps.packages.${system};
         ptitfred = {
           nginx = prev.lib.makeOverridable ({ baseUrl ? "http://localhost" }: prev.callPackage webservers/nginx/package.nix { root = root baseUrl; }) {};
-          take-screenshots = final.callPackage pkgs/take-screenshots {};
+
+          check-screenshots = final.callPackage pkgs/check-screenshots {};
+          take-screenshots  = final.callPackage pkgs/take-screenshots  {};
         };
         puppeteer-cli = final.callPackage pkgs/puppeteer-cli {};
       };
@@ -57,6 +59,7 @@
             pkgs.callPackage tests/in-nginx.nix {
               cores = 2;
               memorySize = 4096;
+              inherit nixosModule;
             };
         };
 
@@ -79,12 +82,15 @@
         ];
       };
 
+      nixosModule = import ./nixos { inherit overlays; };
+
     in
       {
         overlays.default = overlay;
+        nixosModules.default = nixosModule;
 
         packages.${system} = {
-          inherit (pkgs.ptitfred) take-screenshots;
+          inherit (pkgs.ptitfred) take-screenshots check-screenshots;
           inherit scripting;
           nginx-root = pkgs.ptitfred.nginx.root;
           integration-tests = tests.in-nginx;

--- a/flake.nix
+++ b/flake.nix
@@ -86,7 +86,6 @@
 
     in
       {
-        overlays.default = overlay;
         nixosModules.default = nixosModule;
 
         packages.${system} = {

--- a/justfile
+++ b/justfile
@@ -11,4 +11,4 @@ tests:
 	nix run .#tests
 
 integration-tests:
-	nix build .#integration-tests
+	nix build --print-build-logs .#integration-tests

--- a/justfile
+++ b/justfile
@@ -12,3 +12,6 @@ tests:
 
 integration-tests:
 	nix build --print-build-logs .#integration-tests
+
+check-metas:
+	nix run .#check-screenshots https://frederic.menou.me

--- a/nixos/brotli.nix
+++ b/nixos/brotli.nix
@@ -1,0 +1,30 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  enabled = config.services.nginx.enable && config.services.nginx.brotliSupport;
+in
+  {
+    options.services.nginx.brotliSupport = mkOption {
+      type = types.bool;
+      default = false;
+      description = ''
+        If true, nginx will be configured to support Brotli compression.
+      '';
+    };
+
+    config = mkIf enabled {
+      services.nginx.additionalModules = [ pkgs.nginxModules.brotli ];
+      services.nginx.appendHttpConfig = ''
+          brotli on;
+          brotli_comp_level 6;
+          brotli_static on;
+          brotli_types application/atom+xml application/javascript application/json application/rss+xml
+                 application/vnd.ms-fontobject application/x-font-opentype application/x-font-truetype
+                 application/x-font-ttf application/x-javascript application/xhtml+xml application/xml
+                 font/eot font/opentype font/otf font/truetype image/svg+xml image/vnd.microsoft.icon
+                 image/x-icon image/x-win-bitmap text/css text/javascript text/plain text/xml;
+        '';
+    };
+  }

--- a/nixos/brotlify.nix
+++ b/nixos/brotlify.nix
@@ -1,0 +1,28 @@
+{ stdenvNoCC
+, lib
+, brotli
+}:
+
+{ src
+, fileExtensions ? [ "html" "js" "css" "json" "txt" "ttf" "ico" "wasm" ]
+}:
+
+let findQuery = lib.flatten (lib.intersperse "-o"
+      (map (ext: [ "-iname" (lib.escapeShellArg "*.${ext}") ]) fileExtensions));
+
+ in stdenvNoCC.mkDerivation {
+      name = "${src.name}-brotlified";
+      inherit src;
+
+      nativeBuildInputs = [ brotli ];
+
+      buildPhase = ''
+        find . -type f,l \( \
+          ${lib.concatStringsSep " " findQuery} \
+          \) -print0 | xargs -0 -P $NIX_BUILD_CORES -I{} brotli -vZk {}
+      '';
+
+      installPhase = ''
+        cp -r . $out
+      '';
+    }

--- a/nixos/default.nix
+++ b/nixos/default.nix
@@ -1,0 +1,9 @@
+{ overlays }:
+
+{ ... }:
+
+{
+  imports = [ ./website.nix ];
+
+  nixpkgs.overlays = overlays;
+}

--- a/nixos/website.nix
+++ b/nixos/website.nix
@@ -11,7 +11,7 @@ let
 
   nginx = pkgs.ptitfred.nginx.override { inherit baseUrl; };
 
-  baseUrl = "https://${cfg.domain}";
+  baseUrl = if cfg.secure then "https://${cfg.domain}" else "http://${cfg.domain}";
 
   assetsDirectory = "homepage-extra-assets";
   screenshotsSubdirectory = "og";

--- a/nixos/website.nix
+++ b/nixos/website.nix
@@ -1,0 +1,172 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.services.ptitfred.personal-homepage;
+
+  enabled = cfg.enable && config.services.nginx.enable;
+
+  brotlify = pkgs.callPackage ./brotlify.nix { };
+
+  nginx = pkgs.ptitfred.nginx.override { inherit baseUrl; };
+
+  baseUrl = "https://${cfg.domain}";
+
+  assetsDirectory = "homepage-extra-assets";
+  screenshotsSubdirectory = "og";
+
+  mkRedirect = alias: vhosts: vhosts // redirect alias;
+
+  vhostRedirectionBaseDefinition = {
+    forceSSL = cfg.secure;
+    enableACME = cfg.secure;
+    globalRedirect = cfg.domain;
+  };
+
+  vhostRedirectionOptionalDefinition =
+    if cfg.secure
+    then { acmeFallbackHost = cfg.domain; }
+    else {};
+
+  redirect = alias: {
+    "${alias}" = vhostRedirectionBaseDefinition // vhostRedirectionOptionalDefinition;
+  };
+
+  mkRedirection = { path, target }: "rewrite ^${path}$ ${target} permanent;";
+
+  extraConfig = ''
+    ${nginx.extraConfig}
+    ${lib.strings.concatMapStringsSep "\n" mkRedirection cfg.redirections}
+  '';
+
+  hostingHost =
+    {
+      ${cfg.domain} = {
+        forceSSL = cfg.secure;
+        enableACME = lib.mkIf cfg.secure true;
+
+        locations."/" = {
+          root = brotlify { src = nginx.root; };
+          inherit extraConfig;
+        };
+
+        locations."/${screenshotsSubdirectory}/" = {
+          root = "/var/lib/${assetsDirectory}";
+        };
+      };
+    };
+
+  virtualHosts = foldr mkRedirect hostingHost cfg.aliases;
+
+  redirection = types.submodule {
+    options = {
+      path = mkOption {
+        type = types.str;
+        default = false;
+      };
+      target = mkOption {
+        type = types.str;
+        default = false;
+      };
+    };
+  };
+in
+  {
+    imports = [
+      ./brotli.nix
+    ];
+
+    options.services.ptitfred.personal-homepage = {
+      enable = mkOption {
+        type = types.bool;
+        default = false;
+        description = ''
+          If enabled, hosts my personal-homepage on this machine (assuming nginx is enabled and listens to the propert ports).
+        '';
+      };
+
+      secure = mkOption {
+        type = types.bool;
+        default = true;
+        description = ''
+          If enabled, sets up HTTPs and enforces it. Defaults to true.
+        '';
+      };
+
+      domain = mkOption {
+        type = types.str;
+        description = ''
+          CNAME to respond to to host the website.
+        '';
+      };
+
+      aliases = mkOption {
+        type = types.listOf types.str;
+        description = ''
+          CNAMEs to respond to by redirecting to the domain set at `services.ptitfred.personal-homepage.domain`.
+        '';
+        default = [];
+      };
+
+      redirections = mkOption {
+        type = types.listOf redirection;
+        description = ''
+          Extra URL redirections to inject and that you might not want to have publicly committed.
+        '';
+        default = [];
+      };
+
+      screenshots = mkEnableOption "screenshots" // {
+        description = ''
+          Option to enable automatic screenshoting (at 2 in the morning local time).
+        '';
+        default = true;
+      };
+    };
+
+    config = mkIf enabled {
+      services.nginx = {
+        inherit virtualHosts;
+        recommendedGzipSettings = true;
+        recommendedProxySettings = true;
+        brotliSupport = true;
+      };
+
+      systemd.services.homepage-screenshots = {
+        description = "Utility to take screenshots.";
+
+        after    = [ "nginx.service" ];
+        requires = [ "nginx.service" ];
+        partOf = [ "default.target" ];
+
+        script = ''
+          mkdir -p /var/lib/${assetsDirectory}/${screenshotsSubdirectory}
+          ${pkgs.ptitfred.take-screenshots}/bin/take-screenshots ${baseUrl} /var/lib/${assetsDirectory}/${screenshotsSubdirectory}
+        '';
+
+        serviceConfig = {
+          StateDirectory = assetsDirectory;
+          StateDirectoryMode = "0750";
+          User = "nginx";
+          Group = "nginx";
+          Type = "oneshot";
+        };
+
+        environment = {
+          XDG_CONFIG_HOME = "/tmp/.chromium";
+          XDG_CACHE_HOME = "/tmp/.chromium";
+        };
+      };
+
+      systemd.timers.homepage-screenshots = mkIf cfg.screenshots {
+        description = "Utility to take screenshots.";
+        timerConfig.OnCalendar = "02:00:00";
+        wantedBy = [ "timers.target" ];
+      };
+
+      security.acme.certs.${cfg.domain} = lib.mkIf cfg.secure {
+        extraDomainNames = lib.mkIf cfg.secure cfg.aliases;
+      };
+    };
+  }

--- a/pkgs/check-screenshots/default.nix
+++ b/pkgs/check-screenshots/default.nix
@@ -1,0 +1,12 @@
+{ writeShellApplication
+, curl
+, findutils
+, htmlq
+, httpie
+}:
+
+writeShellApplication {
+  name = "check-screenshots";
+  runtimeInputs = [ curl findutils htmlq httpie ];
+  text = builtins.readFile ./script.sh;
+}

--- a/pkgs/check-screenshots/script.sh
+++ b/pkgs/check-screenshots/script.sh
@@ -1,0 +1,37 @@
+set -e
+
+baseUrl="$1"
+
+function listPages {
+  curl -s "$baseUrl/sitemap.xml" | htmlq -t urlset url loc
+}
+
+function readPath {
+  local url="$1"
+  curl -s "$url" | htmlq 'meta[property="og:image"]' --attribute content
+}
+
+function checkScreenshot {
+  echo -n "$1 "
+  path=$(readPath "$1")
+  if [ -n "$path" ]
+  then
+    http --quiet --check-status --headers GET "${baseUrl}${path}" && echo OK
+  else
+    echo Skipped
+  fi
+}
+
+function checkScreenshots {
+  readarray -t urls
+  for url in "${urls[@]}"
+  do
+    checkScreenshot "$url"
+  done
+}
+
+function proceed {
+  listPages | checkScreenshots
+}
+
+proceed

--- a/pkgs/check-screenshots/script.sh
+++ b/pkgs/check-screenshots/script.sh
@@ -11,14 +11,18 @@ function readPath {
   curl -s "$url" | htmlq 'meta[property="og:image"]' --attribute content
 }
 
+function clearLine {
+  echo -en "\r\033[K"
+}
+
 function checkScreenshot {
   echo -n "$1 "
   path=$(readPath "$1")
   if [ -n "$path" ]
   then
-    http --quiet --check-status --headers GET "${baseUrl}${path}" && echo OK
+    http --quiet --check-status --headers GET "${baseUrl}${path}" && echo "✅"
   else
-    echo Skipped
+    clearLine
   fi
 }
 

--- a/pkgs/take-screenshots/default.nix
+++ b/pkgs/take-screenshots/default.nix
@@ -9,5 +9,5 @@
 writeShellApplication {
   name = "take-screenshots";
   runtimeInputs = [ curl findutils htmlq imagemagick puppeteer-cli ];
-  text = builtins.readFile ./take-screenshots.sh;
+  text = builtins.readFile ./script.sh;
 }

--- a/pkgs/take-screenshots/script.sh
+++ b/pkgs/take-screenshots/script.sh
@@ -33,7 +33,11 @@ function takeScreenshot {
 }
 
 function takeScreenshots {
-  while read -r url ; do takeScreenshot "$url" ; done
+  readarray -t urls
+  for url in "${urls[@]}"
+  do
+    takeScreenshot "$url"
+  done
 }
 
 function proceed {

--- a/tests/in-nginx.nix
+++ b/tests/in-nginx.nix
@@ -17,7 +17,14 @@ nixosTest {
 
     services.ptitfred.personal-homepage = {
       enable = true;
-      domain = "localhost";
+      domain = "long.test.localhost";
+      aliases = [ "test.localhost" ];
+      redirections = [
+        { path = "/example";  target = "http://long.test.localhost/open-source"; }
+        { path = "/example/"; target = "http://long.test.localhost/open-source"; }
+      ];
+
+      # Explicitly disable HTTPs as we can't have the ACME dance in the VM
       secure = false;
     };
 

--- a/tests/integration-test.py
+++ b/tests/integration-test.py
@@ -2,18 +2,26 @@ machine.start()
 machine.wait_for_unit("nginx.service")
 
 with subtest("Base files present"):
-  machine.succeed("http --check-status http://localhost/index.html")
-  machine.succeed("http --check-status http://localhost/sitemap.xml")
-  machine.succeed("http --check-status http://localhost/robots.txt")
-  machine.succeed("http --check-status http://localhost/rss.xml")
+  machine.succeed("http --check-status http://long.test.localhost/index.html")
+  machine.succeed("http --check-status http://long.test.localhost/sitemap.xml")
+  machine.succeed("http --check-status http://long.test.localhost/robots.txt")
+  machine.succeed("http --check-status http://long.test.localhost/rss.xml")
+
+with subtest("Aliases"):
+  machine.succeed("http --check-status --follow http://test.localhost")
+  machine.succeed("http --check-status --follow http://test.localhost/index.html")
 
 with subtest("Legacy URLs still there (by redirections)"):
-  machine.succeed("http --check-status --follow http://localhost/about.html")
-  machine.succeed("http --check-status --follow http://localhost/resume.html")
-  machine.succeed("http --check-status --follow http://localhost/blog")
-  machine.succeed("http --check-status --follow http://localhost/tutorials")
+  machine.succeed("http --check-status --follow http://long.test.localhost/about.html")
+  machine.succeed("http --check-status --follow http://long.test.localhost/resume.html")
+  machine.succeed("http --check-status --follow http://long.test.localhost/blog")
+  machine.succeed("http --check-status --follow http://long.test.localhost/tutorials")
+
+with subtest("Custom redirections"):
+  machine.succeed("http --check-status --follow http://long.test.localhost/example")
+  machine.succeed("http --check-status --follow http://long.test.localhost/example/")
 
 with subtest("Screenshots"):
   machine.succeed("systemctl cat homepage-screenshots.service")
   machine.succeed("systemctl start homepage-screenshots.service")
-  machine.succeed("check-screenshots http://localhost")
+  machine.succeed("check-screenshots http://long.test.localhost")

--- a/tests/integration-test.py
+++ b/tests/integration-test.py
@@ -2,17 +2,18 @@ machine.start()
 machine.wait_for_unit("nginx.service")
 
 with subtest("Base files present"):
-  machine.succeed("http http://localhost/index.html")
-  machine.succeed("http http://localhost/sitemap.xml")
-  machine.succeed("http http://localhost/robots.txt")
-  machine.succeed("http http://localhost/atom.xml")
+  machine.succeed("http --check-status http://localhost/index.html")
+  machine.succeed("http --check-status http://localhost/sitemap.xml")
+  machine.succeed("http --check-status http://localhost/robots.txt")
+  machine.succeed("http --check-status http://localhost/rss.xml")
 
 with subtest("Legacy URLs still there (by redirections)"):
-  machine.succeed("http http://localhost/about.html")
-  machine.succeed("http http://localhost/resume.html")
-  machine.succeed("http http://localhost/blog")
-  machine.succeed("http http://localhost/tutorials")
+  machine.succeed("http --check-status --follow http://localhost/about.html")
+  machine.succeed("http --check-status --follow http://localhost/resume.html")
+  machine.succeed("http --check-status --follow http://localhost/blog")
+  machine.succeed("http --check-status --follow http://localhost/tutorials")
 
 with subtest("Screenshots"):
-  machine.succeed("su - test_user -c \"mkdir -p screenshots\"")
-  machine.succeed("su - test_user -c \"take-screenshots http://localhost/ screenshots\"")
+  machine.succeed("systemctl cat homepage-screenshots.service")
+  machine.succeed("systemctl start homepage-screenshots.service")
+  machine.succeed("check-screenshots http://localhost")


### PR DESCRIPTION
It's better to have the module (defining the nginx bits and the screenshot service and timers) close to the code.

Its also easier to test the code when a module is already there. The integration tests have been heavily reworked to:
- use the systemd service for screenshoting
- test the actual URLs

Also at this occasion, the redirections tests have been improved to _actually_ test it's a proper redirection.

The check-screenshots script is also available on the command line to check actual setup:

```
$ just check-metas 
nix run .#check-screenshots https://frederic.menou.me
https://frederic.menou.me/ ✅
https://frederic.menou.me/about/ ✅
https://frederic.menou.me/open-source/ ✅
https://frederic.menou.me/resume/ ✅
https://frederic.menou.me/tutorials-and-conferences/ ✅
https://frederic.menou.me/tutorials-and-conferences/advanced-haskell/ ✅
https://frederic.menou.me/tutorials-and-conferences/haskell-for-beginners/ ✅
https://frederic.menou.me/tutorials-and-conferences/haskell-in-production-scalaio/ ✅
https://frederic.menou.me/writings/ ✅
https://frederic.menou.me/writings/bye-haskell-hello-rust/ ✅
https://frederic.menou.me/writings/nix-derivation-website/ ✅
https://frederic.menou.me/writings/retrospective-2023/ ✅
https://frederic.menou.me/writings/so-long-fretlink/ ✅
```