### PR TITLE
Resume: hint for the PDF version

### DIFF
--- a/website/sass/resume.scss
+++ b/website/sass/resume.scss
@@ -153,7 +153,29 @@ section.position {
   margin: 2cm;
 }
 
+header.print-helper {
+  a {
+    color: #eeee11;
+  }
+  border: 2px solid purple;
+  border-radius: 8px;
+  color: #f0f0ff;
+  background-color: purple;
+  font-size: 20px;
+  padding: 8px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 16px;
+  font-weight: bold;
+  margin-bottom: 16px;
+}
+
 @media print {
+  header.print-helper {
+    display: none;
+  }
+
   body {
     padding: 0;
     max-width: unset;
@@ -169,6 +191,10 @@ section.position {
 }
 
 @media screen and (max-width: 480px) {
+  header.print-helper {
+    flex-direction: column;
+    gap: 0;
+  }
   body {
     padding: 12px;
   }

--- a/website/templates/resume.html
+++ b/website/templates/resume.html
@@ -15,6 +15,9 @@
     <meta name="twitter:image" content="/og/{{ content_hash }}.png">
   </head>
   <body>
+    <header class="print-helper">
+      <span>Need the PDF version?</span><a href="#" onclick=print()>Click here!</a>
+    </header>
     <hgroup>
       <h1>Frédéric Menou</h1>
       <p class="email">contact@frederic.menou.me</p>


### PR DESCRIPTION
Not very subtle:
![image](https://github.com/user-attachments/assets/74b7f001-a710-483c-ad94-371d35f8a88a)

I don't people to call me and ask for the PDF version. Also don't want to produce the PDF like screenshots.