### PR TITLE
Automated flake inputs updated

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -96,11 +96,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1734875076,
-        "narHash": "sha256-Pzyb+YNG5u3zP79zoi8HXYMs15Q5dfjDgwCdUI5B0nY=",
+        "lastModified": 1735669367,
+        "narHash": "sha256-tfYRbFhMOnYaM4ippqqid3BaLOXoFNdImrfBfCp4zn0=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "1807c2b91223227ad5599d7067a61665c52d1295",
+        "rev": "edf04b75c13c2ac0e54df5ec5c543e300f76f1c9",
         "type": "github"
       },
       "original": {
@@ -112,11 +112,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1734323986,
-        "narHash": "sha256-m/lh6hYMIWDYHCAsn81CDAiXoT3gmxXI9J987W5tZrE=",
+        "lastModified": 1734875076,
+        "narHash": "sha256-Pzyb+YNG5u3zP79zoi8HXYMs15Q5dfjDgwCdUI5B0nY=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "394571358ce82dff7411395829aa6a3aad45b907",
+        "rev": "1807c2b91223227ad5599d7067a61665c52d1295",
         "type": "github"
       },
       "original": {
@@ -134,11 +134,11 @@
         "trapd00r-ls-colors": "trapd00r-ls-colors"
       },
       "locked": {
-        "lastModified": 1734460827,
-        "narHash": "sha256-C5PkF7NyqoFMwzCI3I6oWquIrwoXs3Q/wurbvSAOw+U=",
+        "lastModified": 1734976399,
+        "narHash": "sha256-vFIb8zQNt4k/+rKkX9CObFysyd/z+/sjhUTTCEvkqXQ=",
         "owner": "ptitfred",
         "repo": "posix-toolbox",
-        "rev": "53f70a51b00d78f1fea5e12af9a827bc1bab928a",
+        "rev": "0fcee67de66e1992c9e517fcf4ca16df5e61341e",
         "type": "github"
       },
       "original": {
@@ -173,11 +173,11 @@
     "trapd00r-ls-colors": {
       "flake": false,
       "locked": {
-        "lastModified": 1723826680,
-        "narHash": "sha256-/l4LpOBHPvfg6kmLvK96b5pOjEk9wh5QwfH79h5aVpw=",
+        "lastModified": 1734720078,
+        "narHash": "sha256-ePs7UlgQqh3ptRXUNlY/BDa/1aH9q3dGa3h0or/e6Kk=",
         "owner": "trapd00r",
         "repo": "LS_COLORS",
-        "rev": "20cc87c21f5f54cf86be7e5867af9efc65b8b4e3",
+        "rev": "81e2ebcdc2ed815d17db962055645ccf2125560c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Changes:

```
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/1807c2b91223227ad5599d7067a61665c52d1295' (2024-12-22)
  → 'github:nixos/nixpkgs/edf04b75c13c2ac0e54df5ec5c543e300f76f1c9' (2024-12-31)
• Updated input 'posix-toolbox':
    'github:ptitfred/posix-toolbox/53f70a51b00d78f1fea5e12af9a827bc1bab928a' (2024-12-17)
  → 'github:ptitfred/posix-toolbox/0fcee67de66e1992c9e517fcf4ca16df5e61341e' (2024-12-23)
• Updated input 'posix-toolbox/nixpkgs':
    'github:nixos/nixpkgs/394571358ce82dff7411395829aa6a3aad45b907' (2024-12-16)
  → 'github:nixos/nixpkgs/1807c2b91223227ad5599d7067a61665c52d1295' (2024-12-22)
• Updated input 'posix-toolbox/trapd00r-ls-colors':
    'github:trapd00r/LS_COLORS/20cc87c21f5f54cf86be7e5867af9efc65b8b4e3' (2024-08-16)
  → 'github:trapd00r/LS_COLORS/81e2ebcdc2ed815d17db962055645ccf2125560c' (2024-12-20)
```
