### PR TITLE
Automated flake inputs updated

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -64,11 +64,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1734366194,
-        "narHash": "sha256-vykpJ1xsdkv0j8WOVXrRFHUAdp9NXHpxdnn1F4pYgSw=",
+        "lastModified": 1735344290,
+        "narHash": "sha256-oJDtWPH1oJT34RJK1FSWjwX4qcGOBRkcNQPD0EbSfNM=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "80b0fdf483c5d1cb75aaad909bd390d48673857f",
+        "rev": "613691f285dad87694c2ba1c9e6298d04736292d",
         "type": "github"
       },
       "original": {
@@ -96,11 +96,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1735669367,
-        "narHash": "sha256-tfYRbFhMOnYaM4ippqqid3BaLOXoFNdImrfBfCp4zn0=",
+        "lastModified": 1736061677,
+        "narHash": "sha256-DjkQPnkAfd7eB522PwnkGhOMuT9QVCZspDpJJYyOj60=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "edf04b75c13c2ac0e54df5ec5c543e300f76f1c9",
+        "rev": "cbd8ec4de4469333c82ff40d057350c30e9f7d36",
         "type": "github"
       },
       "original": {
@@ -112,11 +112,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1734875076,
-        "narHash": "sha256-Pzyb+YNG5u3zP79zoi8HXYMs15Q5dfjDgwCdUI5B0nY=",
+        "lastModified": 1735669367,
+        "narHash": "sha256-tfYRbFhMOnYaM4ippqqid3BaLOXoFNdImrfBfCp4zn0=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "1807c2b91223227ad5599d7067a61665c52d1295",
+        "rev": "edf04b75c13c2ac0e54df5ec5c543e300f76f1c9",
         "type": "github"
       },
       "original": {
@@ -134,11 +134,11 @@
         "trapd00r-ls-colors": "trapd00r-ls-colors"
       },
       "locked": {
-        "lastModified": 1734976399,
-        "narHash": "sha256-vFIb8zQNt4k/+rKkX9CObFysyd/z+/sjhUTTCEvkqXQ=",
+        "lastModified": 1736154310,
+        "narHash": "sha256-WwylutYs+jjjSa/tksgRDlfgwbrdEkjhICj0Ycdk+8Y=",
         "owner": "ptitfred",
         "repo": "posix-toolbox",
-        "rev": "0fcee67de66e1992c9e517fcf4ca16df5e61341e",
+        "rev": "1301da3b26c1040b846abb9776702d7057c1fa21",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Changes:

```
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/edf04b75c13c2ac0e54df5ec5c543e300f76f1c9' (2024-12-31)
  → 'github:nixos/nixpkgs/cbd8ec4de4469333c82ff40d057350c30e9f7d36' (2025-01-05)
• Updated input 'posix-toolbox':
    'github:ptitfred/posix-toolbox/0fcee67de66e1992c9e517fcf4ca16df5e61341e' (2024-12-23)
  → 'github:ptitfred/posix-toolbox/1301da3b26c1040b846abb9776702d7057c1fa21' (2025-01-06)
• Updated input 'posix-toolbox/home-manager':
    'github:nix-community/home-manager/80b0fdf483c5d1cb75aaad909bd390d48673857f' (2024-12-16)
  → 'github:nix-community/home-manager/613691f285dad87694c2ba1c9e6298d04736292d' (2024-12-28)
• Updated input 'posix-toolbox/nixpkgs':
    'github:nixos/nixpkgs/1807c2b91223227ad5599d7067a61665c52d1295' (2024-12-22)
  → 'github:nixos/nixpkgs/edf04b75c13c2ac0e54df5ec5c543e300f76f1c9' (2024-12-31)
```
