### PR TITLE
Automated flake inputs updated

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -96,11 +96,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1736061677,
-        "narHash": "sha256-DjkQPnkAfd7eB522PwnkGhOMuT9QVCZspDpJJYyOj60=",
+        "lastModified": 1736684107,
+        "narHash": "sha256-vH5mXxEvZeoGNkqKoCluhTGfoeXCZ1seYhC2pbMN0sg=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "cbd8ec4de4469333c82ff40d057350c30e9f7d36",
+        "rev": "635e887b48521e912a516625eee7df6cf0eba9c1",
         "type": "github"
       },
       "original": {
@@ -112,11 +112,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1735669367,
-        "narHash": "sha256-tfYRbFhMOnYaM4ippqqid3BaLOXoFNdImrfBfCp4zn0=",
+        "lastModified": 1736061677,
+        "narHash": "sha256-DjkQPnkAfd7eB522PwnkGhOMuT9QVCZspDpJJYyOj60=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "edf04b75c13c2ac0e54df5ec5c543e300f76f1c9",
+        "rev": "cbd8ec4de4469333c82ff40d057350c30e9f7d36",
         "type": "github"
       },
       "original": {
@@ -134,11 +134,11 @@
         "trapd00r-ls-colors": "trapd00r-ls-colors"
       },
       "locked": {
-        "lastModified": 1736154310,
-        "narHash": "sha256-WwylutYs+jjjSa/tksgRDlfgwbrdEkjhICj0Ycdk+8Y=",
+        "lastModified": 1736207241,
+        "narHash": "sha256-L9AsWOVEkpW01OKHRvhdc05fgtlPShjJc5BNnaXAtWE=",
         "owner": "ptitfred",
         "repo": "posix-toolbox",
-        "rev": "1301da3b26c1040b846abb9776702d7057c1fa21",
+        "rev": "d01dd5e7e1c4c99a412a525f2e77e82022f3a0ff",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Changes:

```
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/cbd8ec4de4469333c82ff40d057350c30e9f7d36' (2025-01-05)
  → 'github:nixos/nixpkgs/635e887b48521e912a516625eee7df6cf0eba9c1' (2025-01-12)
• Updated input 'posix-toolbox':
    'github:ptitfred/posix-toolbox/1301da3b26c1040b846abb9776702d7057c1fa21' (2025-01-06)
  → 'github:ptitfred/posix-toolbox/d01dd5e7e1c4c99a412a525f2e77e82022f3a0ff' (2025-01-06)
• Updated input 'posix-toolbox/nixpkgs':
    'github:nixos/nixpkgs/edf04b75c13c2ac0e54df5ec5c543e300f76f1c9' (2024-12-31)
  → 'github:nixos/nixpkgs/cbd8ec4de4469333c82ff40d057350c30e9f7d36' (2025-01-05)
```
