### PR TITLE
Automated flake inputs updated

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -64,11 +64,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1735344290,
-        "narHash": "sha256-oJDtWPH1oJT34RJK1FSWjwX4qcGOBRkcNQPD0EbSfNM=",
+        "lastModified": 1736373539,
+        "narHash": "sha256-dinzAqCjenWDxuy+MqUQq0I4zUSfaCvN9rzuCmgMZJY=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "613691f285dad87694c2ba1c9e6298d04736292d",
+        "rev": "bd65bc3cde04c16755955630b344bc9e35272c56",
         "type": "github"
       },
       "original": {
@@ -96,11 +96,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1736684107,
-        "narHash": "sha256-vH5mXxEvZeoGNkqKoCluhTGfoeXCZ1seYhC2pbMN0sg=",
+        "lastModified": 1737299813,
+        "narHash": "sha256-Qw2PwmkXDK8sPQ5YQ/y/icbQ+TYgbxfjhgnkNJyT1X8=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "635e887b48521e912a516625eee7df6cf0eba9c1",
+        "rev": "107d5ef05c0b1119749e381451389eded30fb0d5",
         "type": "github"
       },
       "original": {
@@ -112,11 +112,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1736061677,
-        "narHash": "sha256-DjkQPnkAfd7eB522PwnkGhOMuT9QVCZspDpJJYyOj60=",
+        "lastModified": 1737299813,
+        "narHash": "sha256-Qw2PwmkXDK8sPQ5YQ/y/icbQ+TYgbxfjhgnkNJyT1X8=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "cbd8ec4de4469333c82ff40d057350c30e9f7d36",
+        "rev": "107d5ef05c0b1119749e381451389eded30fb0d5",
         "type": "github"
       },
       "original": {
@@ -134,11 +134,11 @@
         "trapd00r-ls-colors": "trapd00r-ls-colors"
       },
       "locked": {
-        "lastModified": 1736207241,
-        "narHash": "sha256-L9AsWOVEkpW01OKHRvhdc05fgtlPShjJc5BNnaXAtWE=",
+        "lastModified": 1737385955,
+        "narHash": "sha256-7ZjaevnCGdpNPeVyUCkkQr7SFmmFxGw9ajiLScQRo2o=",
         "owner": "ptitfred",
         "repo": "posix-toolbox",
-        "rev": "d01dd5e7e1c4c99a412a525f2e77e82022f3a0ff",
+        "rev": "e980f84939a9e70fbe1cb9b9fb383391a1017dda",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Changes:

```
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/635e887b48521e912a516625eee7df6cf0eba9c1' (2025-01-12)
  → 'github:nixos/nixpkgs/107d5ef05c0b1119749e381451389eded30fb0d5' (2025-01-19)
• Updated input 'posix-toolbox':
    'github:ptitfred/posix-toolbox/d01dd5e7e1c4c99a412a525f2e77e82022f3a0ff' (2025-01-06)
  → 'github:ptitfred/posix-toolbox/e980f84939a9e70fbe1cb9b9fb383391a1017dda' (2025-01-20)
• Updated input 'posix-toolbox/home-manager':
    'github:nix-community/home-manager/613691f285dad87694c2ba1c9e6298d04736292d' (2024-12-28)
  → 'github:nix-community/home-manager/bd65bc3cde04c16755955630b344bc9e35272c56' (2025-01-08)
• Updated input 'posix-toolbox/nixpkgs':
    'github:nixos/nixpkgs/cbd8ec4de4469333c82ff40d057350c30e9f7d36' (2025-01-05)
  → 'github:nixos/nixpkgs/107d5ef05c0b1119749e381451389eded30fb0d5' (2025-01-19)
```
