### PR TITLE
Automated flake inputs updated

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -96,11 +96,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1737885640,
-        "narHash": "sha256-GFzPxJzTd1rPIVD4IW+GwJlyGwBDV1Tj5FLYwDQQ9sM=",
+        "lastModified": 1738702386,
+        "narHash": "sha256-nJj8f78AYAxl/zqLiFGXn5Im1qjFKU8yBPKoWEeZN5M=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "4e96537f163fad24ed9eb317798a79afc85b51b7",
+        "rev": "030ba1976b7c0e1a67d9716b17308ccdab5b381e",
         "type": "github"
       },
       "original": {
@@ -112,11 +112,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1737672001,
-        "narHash": "sha256-YnHJJ19wqmibLQdUeq9xzE6CjrMA568KN/lFPuSVs4I=",
+        "lastModified": 1738435198,
+        "narHash": "sha256-5+Hmo4nbqw8FrW85FlNm4IIrRnZ7bn0cmXlScNsNRLo=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "035f8c0853c2977b24ffc4d0a42c74f00b182cd8",
+        "rev": "f6687779bf4c396250831aa5a32cbfeb85bb07a3",
         "type": "github"
       },
       "original": {
@@ -134,11 +134,11 @@
         "trapd00r-ls-colors": "trapd00r-ls-colors"
       },
       "locked": {
-        "lastModified": 1737970022,
-        "narHash": "sha256-YX3D8xOZzGCZOrkqOXQBFXYeH9PEL3dvmdPmMFl+4I8=",
+        "lastModified": 1738849379,
+        "narHash": "sha256-gajMNUETuLsBiupmjq08LDSuoe+6NmRQrryuN1IWC4w=",
         "owner": "ptitfred",
         "repo": "posix-toolbox",
-        "rev": "75bc5109f4d32941da0d1ad792fb721deb9e545f",
+        "rev": "adfda072b652df11ebe10a0cc1cd0945fb6bb308",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Changes:

```
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/4e96537f163fad24ed9eb317798a79afc85b51b7' (2025-01-26)
  → 'github:nixos/nixpkgs/030ba1976b7c0e1a67d9716b17308ccdab5b381e' (2025-02-04)
• Updated input 'posix-toolbox':
    'github:ptitfred/posix-toolbox/75bc5109f4d32941da0d1ad792fb721deb9e545f' (2025-01-27)
  → 'github:ptitfred/posix-toolbox/adfda072b652df11ebe10a0cc1cd0945fb6bb308' (2025-02-06)
• Updated input 'posix-toolbox/nixpkgs':
    'github:nixos/nixpkgs/035f8c0853c2977b24ffc4d0a42c74f00b182cd8' (2025-01-23)
  → 'github:nixos/nixpkgs/f6687779bf4c396250831aa5a32cbfeb85bb07a3' (2025-02-01)
```
