### PR TITLE
Automated flake inputs updated

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -96,11 +96,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1738702386,
-        "narHash": "sha256-nJj8f78AYAxl/zqLiFGXn5Im1qjFKU8yBPKoWEeZN5M=",
+        "lastModified": 1739055578,
+        "narHash": "sha256-2MhC2Bgd06uI1A0vkdNUyDYsMD0SLNGKtD8600mZ69A=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "030ba1976b7c0e1a67d9716b17308ccdab5b381e",
+        "rev": "a45fa362d887f4d4a7157d95c28ca9ce2899b70e",
         "type": "github"
       },
       "original": {
@@ -112,11 +112,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1738435198,
-        "narHash": "sha256-5+Hmo4nbqw8FrW85FlNm4IIrRnZ7bn0cmXlScNsNRLo=",
+        "lastModified": 1739055578,
+        "narHash": "sha256-2MhC2Bgd06uI1A0vkdNUyDYsMD0SLNGKtD8600mZ69A=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "f6687779bf4c396250831aa5a32cbfeb85bb07a3",
+        "rev": "a45fa362d887f4d4a7157d95c28ca9ce2899b70e",
         "type": "github"
       },
       "original": {
@@ -134,11 +134,11 @@
         "trapd00r-ls-colors": "trapd00r-ls-colors"
       },
       "locked": {
-        "lastModified": 1738849379,
-        "narHash": "sha256-gajMNUETuLsBiupmjq08LDSuoe+6NmRQrryuN1IWC4w=",
+        "lastModified": 1739200464,
+        "narHash": "sha256-yGH1oaqzzmJRAtXUrrdQBFd7UOjRrsaq+RdyWIJmMMI=",
         "owner": "ptitfred",
         "repo": "posix-toolbox",
-        "rev": "adfda072b652df11ebe10a0cc1cd0945fb6bb308",
+        "rev": "778ec00a553bdcecaee782dafc4eb4db568913ad",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Changes:

```
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/030ba1976b7c0e1a67d9716b17308ccdab5b381e' (2025-02-04)
  → 'github:nixos/nixpkgs/a45fa362d887f4d4a7157d95c28ca9ce2899b70e' (2025-02-08)
• Updated input 'posix-toolbox':
    'github:ptitfred/posix-toolbox/adfda072b652df11ebe10a0cc1cd0945fb6bb308' (2025-02-06)
  → 'github:ptitfred/posix-toolbox/778ec00a553bdcecaee782dafc4eb4db568913ad' (2025-02-10)
• Updated input 'posix-toolbox/nixpkgs':
    'github:nixos/nixpkgs/f6687779bf4c396250831aa5a32cbfeb85bb07a3' (2025-02-01)
  → 'github:nixos/nixpkgs/a45fa362d887f4d4a7157d95c28ca9ce2899b70e' (2025-02-08)
```
