### PR TITLE
Automated flake inputs updated

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -64,11 +64,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1736373539,
-        "narHash": "sha256-dinzAqCjenWDxuy+MqUQq0I4zUSfaCvN9rzuCmgMZJY=",
+        "lastModified": 1739757849,
+        "narHash": "sha256-Gs076ot1YuAAsYVcyidLKUMIc4ooOaRGO0PqTY7sBzA=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "bd65bc3cde04c16755955630b344bc9e35272c56",
+        "rev": "9d3d080aec2a35e05a15cedd281c2384767c2cfe",
         "type": "github"
       },
       "original": {
@@ -96,11 +96,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1740339700,
-        "narHash": "sha256-cbrw7EgQhcdFnu6iS3vane53bEagZQy/xyIkDWpCgVE=",
+        "lastModified": 1740463929,
+        "narHash": "sha256-4Xhu/3aUdCKeLfdteEHMegx5ooKQvwPHNkOgNCXQrvc=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "04ef94c4c1582fd485bbfdb8c4a8ba250e359195",
+        "rev": "5d7db4668d7a0c6cc5fc8cf6ef33b008b2b1ed8b",
         "type": "github"
       },
       "original": {
@@ -112,11 +112,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1739055578,
-        "narHash": "sha256-2MhC2Bgd06uI1A0vkdNUyDYsMD0SLNGKtD8600mZ69A=",
+        "lastModified": 1740339700,
+        "narHash": "sha256-cbrw7EgQhcdFnu6iS3vane53bEagZQy/xyIkDWpCgVE=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "a45fa362d887f4d4a7157d95c28ca9ce2899b70e",
+        "rev": "04ef94c4c1582fd485bbfdb8c4a8ba250e359195",
         "type": "github"
       },
       "original": {
@@ -134,11 +134,11 @@
         "trapd00r-ls-colors": "trapd00r-ls-colors"
       },
       "locked": {
-        "lastModified": 1739200464,
-        "narHash": "sha256-yGH1oaqzzmJRAtXUrrdQBFd7UOjRrsaq+RdyWIJmMMI=",
+        "lastModified": 1740476566,
+        "narHash": "sha256-OJrWZD4TAZw+/Cj4vtORo+/da2mwOrk1reraNcwWl6w=",
         "owner": "ptitfred",
         "repo": "posix-toolbox",
-        "rev": "778ec00a553bdcecaee782dafc4eb4db568913ad",
+        "rev": "12b8dee2e1682d595e48b607374ea12950d126d8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Changes:

```
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/04ef94c4c1582fd485bbfdb8c4a8ba250e359195' (2025-02-23)
  → 'github:nixos/nixpkgs/5d7db4668d7a0c6cc5fc8cf6ef33b008b2b1ed8b' (2025-02-25)
• Updated input 'posix-toolbox':
    'github:ptitfred/posix-toolbox/778ec00a553bdcecaee782dafc4eb4db568913ad' (2025-02-10)
  → 'github:ptitfred/posix-toolbox/12b8dee2e1682d595e48b607374ea12950d126d8' (2025-02-25)
• Updated input 'posix-toolbox/home-manager':
    'github:nix-community/home-manager/bd65bc3cde04c16755955630b344bc9e35272c56' (2025-01-08)
  → 'github:nix-community/home-manager/9d3d080aec2a35e05a15cedd281c2384767c2cfe' (2025-02-17)
• Updated input 'posix-toolbox/nixpkgs':
    'github:nixos/nixpkgs/a45fa362d887f4d4a7157d95c28ca9ce2899b70e' (2025-02-08)
  → 'github:nixos/nixpkgs/04ef94c4c1582fd485bbfdb8c4a8ba250e359195' (2025-02-23)
```
