### PR TITLE
Automated flake inputs updated

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -96,11 +96,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1740463929,
-        "narHash": "sha256-4Xhu/3aUdCKeLfdteEHMegx5ooKQvwPHNkOgNCXQrvc=",
+        "lastModified": 1741445498,
+        "narHash": "sha256-F5Em0iv/CxkN5mZ9hRn3vPknpoWdcdCyR0e4WklHwiE=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "5d7db4668d7a0c6cc5fc8cf6ef33b008b2b1ed8b",
+        "rev": "52e3095f6d812b91b22fb7ad0bfc1ab416453634",
         "type": "github"
       },
       "original": {
@@ -112,11 +112,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1740339700,
-        "narHash": "sha256-cbrw7EgQhcdFnu6iS3vane53bEagZQy/xyIkDWpCgVE=",
+        "lastModified": 1741048562,
+        "narHash": "sha256-W4YZ3fvWZiFYYyd900kh8P8wU6DHSiwaH0j4+fai1Sk=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "04ef94c4c1582fd485bbfdb8c4a8ba250e359195",
+        "rev": "6af28b834daca767a7ef99f8a7defa957d0ade6f",
         "type": "github"
       },
       "original": {
@@ -134,11 +134,11 @@
         "trapd00r-ls-colors": "trapd00r-ls-colors"
       },
       "locked": {
-        "lastModified": 1740476566,
-        "narHash": "sha256-OJrWZD4TAZw+/Cj4vtORo+/da2mwOrk1reraNcwWl6w=",
+        "lastModified": 1741291204,
+        "narHash": "sha256-sLu6IHL9w+GNOpW7pUSrFIdpZDD4v+P2hjVYuu0wJ0I=",
         "owner": "ptitfred",
         "repo": "posix-toolbox",
-        "rev": "12b8dee2e1682d595e48b607374ea12950d126d8",
+        "rev": "ad216fdefe8398d7de6ee1a3f7d92e2380d7f51d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Changes:

```
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/5d7db4668d7a0c6cc5fc8cf6ef33b008b2b1ed8b' (2025-02-25)
  → 'github:nixos/nixpkgs/52e3095f6d812b91b22fb7ad0bfc1ab416453634' (2025-03-08)
• Updated input 'posix-toolbox':
    'github:ptitfred/posix-toolbox/12b8dee2e1682d595e48b607374ea12950d126d8' (2025-02-25)
  → 'github:ptitfred/posix-toolbox/ad216fdefe8398d7de6ee1a3f7d92e2380d7f51d' (2025-03-06)
• Updated input 'posix-toolbox/nixpkgs':
    'github:nixos/nixpkgs/04ef94c4c1582fd485bbfdb8c4a8ba250e359195' (2025-02-23)
  → 'github:nixos/nixpkgs/6af28b834daca767a7ef99f8a7defa957d0ade6f' (2025-03-04)
```
