### PR TITLE
Automated flake inputs updated

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -64,11 +64,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1739757849,
-        "narHash": "sha256-Gs076ot1YuAAsYVcyidLKUMIc4ooOaRGO0PqTY7sBzA=",
+        "lastModified": 1742655702,
+        "narHash": "sha256-jbqlw4sPArFtNtA1s3kLg7/A4fzP4GLk9bGbtUJg0JQ=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "9d3d080aec2a35e05a15cedd281c2384767c2cfe",
+        "rev": "0948aeedc296f964140d9429223c7e4a0702a1ff",
         "type": "github"
       },
       "original": {
@@ -96,11 +96,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1743367904,
-        "narHash": "sha256-sOos1jZGKmT6xxPvxGQyPTApOunXvScV4lNjBCXd/CI=",
+        "lastModified": 1743576891,
+        "narHash": "sha256-vXiKURtntURybE6FMNFAVpRPr8+e8KoLPrYs9TGuAKc=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "7ffe0edc685f14b8c635e3d6591b0bbb97365e6c",
+        "rev": "44a69ed688786e98a101f02b712c313f1ade37ab",
         "type": "github"
       },
       "original": {
@@ -112,11 +112,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1741048562,
-        "narHash": "sha256-W4YZ3fvWZiFYYyd900kh8P8wU6DHSiwaH0j4+fai1Sk=",
+        "lastModified": 1742937945,
+        "narHash": "sha256-lWc+79eZRyvHp/SqMhHTMzZVhpxkRvthsP1Qx6UCq0E=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "6af28b834daca767a7ef99f8a7defa957d0ade6f",
+        "rev": "d02d88f8de5b882ccdde0465d8fa2db3aa1169f7",
         "type": "github"
       },
       "original": {
@@ -134,11 +134,11 @@
         "trapd00r-ls-colors": "trapd00r-ls-colors"
       },
       "locked": {
-        "lastModified": 1741291204,
-        "narHash": "sha256-sLu6IHL9w+GNOpW7pUSrFIdpZDD4v+P2hjVYuu0wJ0I=",
+        "lastModified": 1743677187,
+        "narHash": "sha256-2DVjO/poPpy2F6DVhVJFW6tCZ0NNg5HfwdfHJ42Tm+Y=",
         "owner": "ptitfred",
         "repo": "posix-toolbox",
-        "rev": "ad216fdefe8398d7de6ee1a3f7d92e2380d7f51d",
+        "rev": "c3de8d68476f6eb451d5f9496857156450986b3c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Changes:

```
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/7ffe0edc685f14b8c635e3d6591b0bbb97365e6c' (2025-03-30)
  → 'github:nixos/nixpkgs/44a69ed688786e98a101f02b712c313f1ade37ab' (2025-04-02)
• Updated input 'posix-toolbox':
    'github:ptitfred/posix-toolbox/ad216fdefe8398d7de6ee1a3f7d92e2380d7f51d' (2025-03-06)
  → 'github:ptitfred/posix-toolbox/c3de8d68476f6eb451d5f9496857156450986b3c' (2025-04-03)
• Updated input 'posix-toolbox/home-manager':
    'github:nix-community/home-manager/9d3d080aec2a35e05a15cedd281c2384767c2cfe' (2025-02-17)
  → 'github:nix-community/home-manager/0948aeedc296f964140d9429223c7e4a0702a1ff' (2025-03-22)
• Updated input 'posix-toolbox/nixpkgs':
    'github:nixos/nixpkgs/6af28b834daca767a7ef99f8a7defa957d0ade6f' (2025-03-04)
  → 'github:nixos/nixpkgs/d02d88f8de5b882ccdde0465d8fa2db3aa1169f7' (2025-03-25)
```
