### PR TITLE
Automated flake inputs updated

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -64,11 +64,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1742655702,
-        "narHash": "sha256-jbqlw4sPArFtNtA1s3kLg7/A4fzP4GLk9bGbtUJg0JQ=",
+        "lastModified": 1743808813,
+        "narHash": "sha256-2lDQBOmlz9ggPxcS7/GvcVdzXMIiT+PpMao6FbLJSr0=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "0948aeedc296f964140d9429223c7e4a0702a1ff",
+        "rev": "a9f8b3db211b4609ddd83683f9db89796c7f6ac6",
         "type": "github"
       },
       "original": {
@@ -96,11 +96,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1743576891,
-        "narHash": "sha256-vXiKURtntURybE6FMNFAVpRPr8+e8KoLPrYs9TGuAKc=",
+        "lastModified": 1743813633,
+        "narHash": "sha256-BgkBz4NpV6Kg8XF7cmHDHRVGZYnKbvG0Y4p+jElwxaM=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "44a69ed688786e98a101f02b712c313f1ade37ab",
+        "rev": "7819a0d29d1dd2bc331bec4b327f0776359b1fa6",
         "type": "github"
       },
       "original": {
@@ -112,11 +112,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1742937945,
-        "narHash": "sha256-lWc+79eZRyvHp/SqMhHTMzZVhpxkRvthsP1Qx6UCq0E=",
+        "lastModified": 1743813633,
+        "narHash": "sha256-BgkBz4NpV6Kg8XF7cmHDHRVGZYnKbvG0Y4p+jElwxaM=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "d02d88f8de5b882ccdde0465d8fa2db3aa1169f7",
+        "rev": "7819a0d29d1dd2bc331bec4b327f0776359b1fa6",
         "type": "github"
       },
       "original": {
@@ -134,11 +134,11 @@
         "trapd00r-ls-colors": "trapd00r-ls-colors"
       },
       "locked": {
-        "lastModified": 1743677187,
-        "narHash": "sha256-2DVjO/poPpy2F6DVhVJFW6tCZ0NNg5HfwdfHJ42Tm+Y=",
+        "lastModified": 1744037494,
+        "narHash": "sha256-ZW6wYS8KlZBgf+dNrtwy0Ixe1q7/EFBb2IPSZrnsETY=",
         "owner": "ptitfred",
         "repo": "posix-toolbox",
-        "rev": "c3de8d68476f6eb451d5f9496857156450986b3c",
+        "rev": "815f01cce4c91dc4aaddcd6c8c2162094262e565",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Changes:

```
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/44a69ed688786e98a101f02b712c313f1ade37ab' (2025-04-02)
  → 'github:nixos/nixpkgs/7819a0d29d1dd2bc331bec4b327f0776359b1fa6' (2025-04-05)
• Updated input 'posix-toolbox':
    'github:ptitfred/posix-toolbox/c3de8d68476f6eb451d5f9496857156450986b3c' (2025-04-03)
  → 'github:ptitfred/posix-toolbox/815f01cce4c91dc4aaddcd6c8c2162094262e565' (2025-04-07)
• Updated input 'posix-toolbox/home-manager':
    'github:nix-community/home-manager/0948aeedc296f964140d9429223c7e4a0702a1ff' (2025-03-22)
  → 'github:nix-community/home-manager/a9f8b3db211b4609ddd83683f9db89796c7f6ac6' (2025-04-04)
• Updated input 'posix-toolbox/nixpkgs':
    'github:nixos/nixpkgs/d02d88f8de5b882ccdde0465d8fa2db3aa1169f7' (2025-03-25)
  → 'github:nixos/nixpkgs/7819a0d29d1dd2bc331bec4b327f0776359b1fa6' (2025-04-05)
```
