### PR TITLE
Automated flake inputs updated

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -64,11 +64,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1743808813,
-        "narHash": "sha256-2lDQBOmlz9ggPxcS7/GvcVdzXMIiT+PpMao6FbLJSr0=",
+        "lastModified": 1744117652,
+        "narHash": "sha256-t7dFCDl4vIOOUMhEZnJF15aAzkpaup9x4ZRGToDFYWI=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "a9f8b3db211b4609ddd83683f9db89796c7f6ac6",
+        "rev": "b4e98224ad1336751a2ac7493967a4c9f6d9cb3f",
         "type": "github"
       },
       "original": {
@@ -112,11 +112,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1743813633,
-        "narHash": "sha256-BgkBz4NpV6Kg8XF7cmHDHRVGZYnKbvG0Y4p+jElwxaM=",
+        "lastModified": 1744168086,
+        "narHash": "sha256-S9M4HddBCxbbX1CKSyDYgZ8NCVyHcbKnBfoUXeRu2jQ=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "7819a0d29d1dd2bc331bec4b327f0776359b1fa6",
+        "rev": "60e405b241edb6f0573f3d9f944617fe33ac4a73",
         "type": "github"
       },
       "original": {
@@ -134,11 +134,11 @@
         "trapd00r-ls-colors": "trapd00r-ls-colors"
       },
       "locked": {
-        "lastModified": 1744037494,
-        "narHash": "sha256-ZW6wYS8KlZBgf+dNrtwy0Ixe1q7/EFBb2IPSZrnsETY=",
+        "lastModified": 1744646460,
+        "narHash": "sha256-1BtAEdesKps4xKbQhPi026HhvTrUx+6JokmorGTYdec=",
         "owner": "ptitfred",
         "repo": "posix-toolbox",
-        "rev": "815f01cce4c91dc4aaddcd6c8c2162094262e565",
+        "rev": "c9f22170ba92af436344b33d140b2552fcbbfe21",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Changes:

```
• Updated input 'posix-toolbox':
    'github:ptitfred/posix-toolbox/815f01cce4c91dc4aaddcd6c8c2162094262e565' (2025-04-07)
  → 'github:ptitfred/posix-toolbox/c9f22170ba92af436344b33d140b2552fcbbfe21' (2025-04-14)
• Updated input 'posix-toolbox/home-manager':
    'github:nix-community/home-manager/a9f8b3db211b4609ddd83683f9db89796c7f6ac6' (2025-04-04)
  → 'github:nix-community/home-manager/b4e98224ad1336751a2ac7493967a4c9f6d9cb3f' (2025-04-08)
• Updated input 'posix-toolbox/nixpkgs':
    'github:nixos/nixpkgs/7819a0d29d1dd2bc331bec4b327f0776359b1fa6' (2025-04-05)
  → 'github:nixos/nixpkgs/60e405b241edb6f0573f3d9f944617fe33ac4a73' (2025-04-09)
```
